### PR TITLE
Owning contract

### DIFF
--- a/cep47-logic/src/lib.rs
+++ b/cep47-logic/src/lib.rs
@@ -57,7 +57,7 @@ pub trait CEP47Contract<Storage: CEP47Storage>: WithStorage<Storage> {
     }
 
     fn owner_of(&self, token_id: &TokenId) -> Option<Key> {
-        self.storage().onwer_of(token_id)
+        self.storage().owner_of(token_id)
     }
 
     fn total_supply(&self) -> U256 {
@@ -246,7 +246,7 @@ pub trait CEP47Storage {
 
     // Getters
     fn balance_of(&self, owner: &Key) -> U256;
-    fn onwer_of(&self, token_id: &TokenId) -> Option<Key>;
+    fn owner_of(&self, token_id: &TokenId) -> Option<Key>;
     fn total_supply(&self) -> U256;
     fn token_meta(&self, token_id: &TokenId) -> Option<Meta>;
 

--- a/cep47-logic/src/tests.rs
+++ b/cep47-logic/src/tests.rs
@@ -61,7 +61,7 @@ impl CEP47Storage for TestStorage {
         owner_balance.cloned().unwrap_or_default()
     }
 
-    fn onwer_of(&self, token_id: &TokenId) -> Option<Key> {
+    fn owner_of(&self, token_id: &TokenId) -> Option<Key> {
         let owner = self.belongs_to.get(token_id);
         owner.cloned()
     }
@@ -164,7 +164,7 @@ impl CEP47Storage for TestStorage {
 
     fn validate_token_ids(&self, token_ids: &Vec<TokenId>) -> bool {
         for token_id in token_ids {
-            if self.onwer_of(token_id).is_some() {
+            if self.owner_of(token_id).is_some() {
                 return false;
             }
         }

--- a/cep47-tests/src/cep47.rs
+++ b/cep47-tests/src/cep47.rs
@@ -79,6 +79,20 @@ impl CasperCEP47Contract {
         }
     }
 
+    pub fn deploy_secondary_contract(&mut self, wasm: &str, contract_hash_name: &str ,args: RuntimeArgs) -> Hash{
+        let session_code = Code::from(wasm);
+        let session = SessionBuilder::new(session_code, args)
+            .with_address(self.admin)
+            .with_authorization_keys(&[self.admin])
+            .build();
+        self.context.run(session);
+        self.context
+            .query(self.admin, &[contract_hash_name.to_string()])
+            .unwrap()
+            .into_t()
+            .unwrap()
+    }
+
     fn call(&mut self, sender: &AccountHash, method: &str, args: RuntimeArgs) {
         let account = *sender;
         let code = Code::Hash(self.hash, method.to_string());
@@ -140,21 +154,20 @@ impl CasperCEP47Contract {
         self.query_contract("total_supply").unwrap_or_default()
     }
 
-    pub fn owner_of(&self, token_id: &TokenId) -> Option<AccountHash> {
-        let key: Key = self
-            .query_dictionary_value(TOKEN_OWNERS_DICT, token_id.clone())
-            .unwrap();
-        key.into_account()
+    pub fn owner_of(&self, token_id: &TokenId) -> Key {
+        self
+            .query_dictionary_value::<Key>(TOKEN_OWNERS_DICT, token_id.clone())
+            .unwrap()
     }
 
-    pub fn balance_of(&self, owner: &AccountHash) -> U256 {
-        let value: Option<U256> = self.query_dictionary_value(BALANCES_DICT, owner.to_string());
+    pub fn balance_of(&self, owner: &Key) -> U256 {
+        let value: Option<U256> = self.query_dictionary_value(BALANCES_DICT, Self::key_to_str(owner));
         value.unwrap_or_default()
     }
 
-    pub fn tokens(&self, owner: &AccountHash) -> Vec<TokenId> {
+    pub fn tokens(&self, owner: &Key) -> Vec<TokenId> {
         let value: Option<Vec<TokenId>> =
-            self.query_dictionary_value(OWNED_TOKENS_DICT, owner.to_string());
+            self.query_dictionary_value(OWNED_TOKENS_DICT, Self::key_to_str(owner));
         value.unwrap_or_default()
     }
 
@@ -164,7 +177,7 @@ impl CasperCEP47Contract {
 
     pub fn mint_one(
         &mut self,
-        recipient: &AccountHash,
+        recipient: &Key,
         token_id: Option<&TokenId>,
         token_meta: &Meta,
         sender: &AccountHash,
@@ -173,7 +186,7 @@ impl CasperCEP47Contract {
             sender,
             "mint_one",
             runtime_args! {
-                "recipient" => Key::from(*recipient),
+                "recipient" => *recipient,
                 "token_id" => token_id.cloned(),
                 "token_meta" => token_meta.clone()
             },
@@ -296,5 +309,14 @@ impl CasperCEP47Contract {
                 "token_meta" => meta.clone()
             },
         );
+    }
+
+
+    fn key_to_str(key: &Key) -> String {
+        match key {
+            Key::Account(account) => account.to_string(),
+            Key::Hash(package) => hex::encode(package),
+            _ => panic!(),
+        }
     }
 }

--- a/cep47-tests/src/contract_tests.rs
+++ b/cep47-tests/src/contract_tests.rs
@@ -1,5 +1,6 @@
 use crate::cep47::{token_cfg, CasperCEP47Contract, Meta, TokenId};
-use casper_types::U256;
+use casper_engine_test_support::Hash;
+use casper_types::{Key, U256, runtime_args, RuntimeArgs};
 
 mod meta {
     use super::Meta;
@@ -47,7 +48,7 @@ fn test_token_meta() {
     let token_meta = meta::red_dragon();
 
     contract.mint_one(
-        &contract.ali.clone(),
+        &Key::Account(contract.ali),
         Some(&token_id),
         &token_meta,
         &contract.admin.clone(),
@@ -56,7 +57,7 @@ fn test_token_meta() {
     let ali_token_meta = contract.token_meta(&token_id).unwrap();
     assert_eq!(ali_token_meta, token_meta);
 
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(ali_tokens, vec![token_id]);
 }
 
@@ -65,18 +66,18 @@ fn test_mint_one_with_random_token_id() {
     let mut contract = CasperCEP47Contract::deploy();
     let token_meta = meta::red_dragon();
     contract.mint_one(
-        &contract.ali.clone(),
+        &Key::Account(contract.ali),
         None,
         &token_meta,
         &contract.admin.clone(),
     );
 
     assert_eq!(contract.total_supply(), U256::one());
-    assert_eq!(contract.balance_of(&contract.ali), U256::one());
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::one());
 
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::one());
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Some(contract.ali));
+    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.ali));
 }
 
 #[test]
@@ -85,18 +86,18 @@ fn test_mint_one_with_set_token_id() {
     let token_id = TokenId::from("123456");
     let token_meta = meta::red_dragon();
     contract.mint_one(
-        &contract.ali.clone(),
+        &Key::Account(contract.ali),
         Some(&token_id),
         &token_meta,
         &contract.admin.clone(),
     );
 
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(ali_tokens, vec![token_id.clone()]);
     assert_eq!(contract.total_supply(), U256::one());
-    assert_eq!(contract.balance_of(&contract.ali), U256::one());
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::one());
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::one());
-    assert_eq!(contract.owner_of(&token_id), Some(contract.ali));
+    assert_eq!(contract.owner_of(&token_id), Key::Account(contract.ali));
 }
 
 #[test]
@@ -106,13 +107,13 @@ fn test_mint_one_with_not_unique_token_id() {
     let token_id = TokenId::from("123456");
     let token_meta = meta::red_dragon();
     contract.mint_one(
-        &contract.ali.clone(),
+        &Key::Account(contract.ali),
         Some(&token_id),
         &token_meta,
         &contract.admin.clone(),
     );
     contract.mint_one(
-        &contract.ali.clone(),
+        &Key::Account(contract.ali),
         Some(&token_id),
         &token_meta,
         &contract.admin.clone(),
@@ -131,13 +132,13 @@ fn test_mint_copies() {
         &contract.admin.clone(),
     );
 
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(contract.total_supply(), U256::from(3));
-    assert_eq!(contract.balance_of(&contract.ali), U256::from(3));
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(3));
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(3));
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Some(contract.ali));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Some(contract.ali));
-    assert_eq!(contract.owner_of(&ali_tokens[2]), Some(contract.ali));
+    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.ali));
+    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.ali));
+    assert_eq!(contract.owner_of(&ali_tokens[2]), Key::Account(contract.ali));
 }
 
 #[test]
@@ -151,13 +152,13 @@ fn test_mint_many() {
         &contract.admin.clone(),
     );
 
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
 
     assert_eq!(contract.total_supply(), U256::from(2));
-    assert_eq!(contract.balance_of(&contract.ali), U256::from(2));
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(2));
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(2));
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Some(contract.ali));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Some(contract.ali));
+    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.ali));
+    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.ali));
 }
 
 #[test]
@@ -176,7 +177,7 @@ fn test_burn_many() {
         &contract.admin.clone(),
     );
 
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     println!("{:?}", ali_tokens);
     println!("{:?}", ali_tokens.first().unwrap().clone());
 
@@ -189,9 +190,9 @@ fn test_burn_many() {
         &contract.admin.clone(),
     );
     assert_eq!(contract.total_supply(), U256::from(2));
-    assert_eq!(contract.balance_of(&contract.ali), U256::from(2));
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(2));
 
-    let ali_tokens = contract.tokens(&contract.ali);
+    let ali_tokens = contract.tokens(&Key::Account(contract.ali));
     println!("{:?}", ali_tokens);
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(2));
 }
@@ -207,7 +208,7 @@ fn test_burn_one() {
         &contract.admin.clone(),
     );
 
-    let ali_tokens = contract.tokens(&contract.ali);
+    let ali_tokens = contract.tokens(&Key::Account(contract.ali));
 
     contract.burn_one(
         &contract.ali.clone(),
@@ -215,9 +216,9 @@ fn test_burn_one() {
         &contract.admin.clone(),
     );
     assert_eq!(contract.total_supply(), U256::from(1));
-    assert_eq!(contract.balance_of(&contract.ali), U256::from(1));
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(1));
 
-    let ali_tokens = contract.tokens(&contract.ali);
+    let ali_tokens = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(1));
 }
 
@@ -232,15 +233,15 @@ fn test_transfer_token() {
         &contract.admin.clone(),
     );
 
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
 
     contract.transfer_token(&contract.bob.clone(), &ali_tokens[1], &contract.ali.clone());
 
-    assert_eq!(contract.balance_of(&contract.ali), U256::from(1));
-    assert_eq!(contract.balance_of(&contract.bob), U256::from(1));
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(1));
+    assert_eq!(contract.balance_of(&Key::Account(contract.bob)), U256::from(1));
     assert_eq!(contract.total_supply(), U256::from(2));
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Some(contract.ali));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Some(contract.bob));
+    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.ali));
+    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.bob));
 }
 
 #[test]
@@ -257,19 +258,19 @@ fn test_transfer_many_tokens() {
         &token_metas,
         &contract.admin.clone(),
     );
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     contract.transfer_many_tokens(
         &contract.bob.clone(),
         &ali_tokens[..2].to_vec(),
         &contract.ali.clone(),
     );
 
-    assert_eq!(contract.balance_of(&contract.ali), U256::from(1));
-    assert_eq!(contract.balance_of(&contract.bob), U256::from(2));
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(1));
+    assert_eq!(contract.balance_of(&Key::Account(contract.bob)), U256::from(2));
     assert_eq!(contract.total_supply(), U256::from(3));
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Some(contract.bob));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Some(contract.bob));
-    assert_eq!(contract.owner_of(&ali_tokens[2]), Some(contract.ali));
+    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.bob));
+    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.bob));
+    assert_eq!(contract.owner_of(&ali_tokens[2]), Key::Account(contract.ali));
 }
 
 #[test]
@@ -283,15 +284,15 @@ fn test_transfer_all_tokens() {
         &contract.admin.clone(),
     );
 
-    let ali_tokens: Vec<TokenId> = contract.tokens(&contract.ali);
+    let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
 
     contract.transfer_all_tokens(&contract.bob.clone(), &contract.ali.clone());
-    assert_eq!(contract.balance_of(&contract.ali), U256::from(0));
-    assert_eq!(contract.balance_of(&contract.bob), U256::from(2));
+    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(0));
+    assert_eq!(contract.balance_of(&Key::Account(contract.bob)), U256::from(2));
     assert_eq!(contract.total_supply(), U256::from(2));
 
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Some(contract.bob));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Some(contract.bob));
+    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.bob));
+    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.bob));
 }
 
 #[test]
@@ -300,7 +301,7 @@ fn test_token_metadata_update() {
     let token_id = TokenId::from("123456");
     let token_meta = meta::red_dragon();
     contract.mint_one(
-        &contract.ali.clone(),
+        &Key::Account(contract.ali),
         Some(&token_id),
         &token_meta,
         &contract.admin.clone(),
@@ -308,4 +309,25 @@ fn test_token_metadata_update() {
 
     contract.update_token_metadata(&token_id, &meta::blue_dragon(), &contract.admin.clone());
     assert_eq!(contract.token_meta(&token_id).unwrap(), meta::blue_dragon());
+}
+
+#[test]
+fn test_contract_owning_token() {
+    let mut contract = CasperCEP47Contract::deploy();
+    let contract_hash: Hash = contract.deploy_secondary_contract("owning-contract.wasm", "owning_contract_hash", runtime_args!{});
+    let token_id = TokenId::from("123456");
+    let token_meta = meta::red_dragon();
+    contract.mint_one(
+        &Key::Hash(contract_hash),
+        Some(&token_id),
+        &token_meta,
+        &contract.admin.clone(),
+    );
+
+    assert_eq!(contract.total_supply(), U256::from(1));
+    assert_eq!(contract.balance_of(&Key::Hash(contract_hash)), U256::from(1));
+
+    let contracts_tokens: Vec<TokenId> = contract.tokens(&Key::Hash(contract_hash));
+    println!("{:?}", contracts_tokens);
+    assert_eq!(contract.owner_of(&contracts_tokens[0]), Key::Hash(contract_hash));
 }

--- a/cep47-tests/src/contract_tests.rs
+++ b/cep47-tests/src/contract_tests.rs
@@ -1,6 +1,5 @@
 use crate::cep47::{token_cfg, CasperCEP47Contract, Meta, TokenId};
-use casper_engine_test_support::Hash;
-use casper_types::{Key, U256, runtime_args, RuntimeArgs};
+use casper_types::{runtime_args, Key, RuntimeArgs, U256};
 
 mod meta {
     use super::Meta;
@@ -73,11 +72,17 @@ fn test_mint_one_with_random_token_id() {
     );
 
     assert_eq!(contract.total_supply(), U256::one());
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::one());
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::one()
+    );
 
     let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::one());
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.ali));
+    assert_eq!(
+        contract.owner_of(&ali_tokens[0]),
+        Key::Account(contract.ali)
+    );
 }
 
 #[test]
@@ -95,7 +100,10 @@ fn test_mint_one_with_set_token_id() {
     let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(ali_tokens, vec![token_id.clone()]);
     assert_eq!(contract.total_supply(), U256::one());
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::one());
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::one()
+    );
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::one());
     assert_eq!(contract.owner_of(&token_id), Key::Account(contract.ali));
 }
@@ -134,11 +142,23 @@ fn test_mint_copies() {
 
     let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(contract.total_supply(), U256::from(3));
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(3));
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::from(3)
+    );
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(3));
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.ali));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.ali));
-    assert_eq!(contract.owner_of(&ali_tokens[2]), Key::Account(contract.ali));
+    assert_eq!(
+        contract.owner_of(&ali_tokens[0]),
+        Key::Account(contract.ali)
+    );
+    assert_eq!(
+        contract.owner_of(&ali_tokens[1]),
+        Key::Account(contract.ali)
+    );
+    assert_eq!(
+        contract.owner_of(&ali_tokens[2]),
+        Key::Account(contract.ali)
+    );
 }
 
 #[test]
@@ -155,10 +175,19 @@ fn test_mint_many() {
     let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
 
     assert_eq!(contract.total_supply(), U256::from(2));
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(2));
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::from(2)
+    );
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(2));
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.ali));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.ali));
+    assert_eq!(
+        contract.owner_of(&ali_tokens[0]),
+        Key::Account(contract.ali)
+    );
+    assert_eq!(
+        contract.owner_of(&ali_tokens[1]),
+        Key::Account(contract.ali)
+    );
 }
 
 #[test]
@@ -190,7 +219,10 @@ fn test_burn_many() {
         &contract.admin.clone(),
     );
     assert_eq!(contract.total_supply(), U256::from(2));
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(2));
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::from(2)
+    );
 
     let ali_tokens = contract.tokens(&Key::Account(contract.ali));
     println!("{:?}", ali_tokens);
@@ -216,7 +248,10 @@ fn test_burn_one() {
         &contract.admin.clone(),
     );
     assert_eq!(contract.total_supply(), U256::from(1));
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(1));
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::from(1)
+    );
 
     let ali_tokens = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(1));
@@ -235,13 +270,29 @@ fn test_transfer_token() {
 
     let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
 
-    contract.transfer_token(&contract.bob.clone(), &ali_tokens[1], &contract.ali.clone());
+    contract.transfer_token(
+        &Key::Account(contract.bob),
+        &ali_tokens[1],
+        &contract.ali.clone(),
+    );
 
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(1));
-    assert_eq!(contract.balance_of(&Key::Account(contract.bob)), U256::from(1));
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::from(1)
+    );
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.bob)),
+        U256::from(1)
+    );
     assert_eq!(contract.total_supply(), U256::from(2));
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.ali));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.bob));
+    assert_eq!(
+        contract.owner_of(&ali_tokens[0]),
+        Key::Account(contract.ali)
+    );
+    assert_eq!(
+        contract.owner_of(&ali_tokens[1]),
+        Key::Account(contract.bob)
+    );
 }
 
 #[test]
@@ -265,12 +316,27 @@ fn test_transfer_many_tokens() {
         &contract.ali.clone(),
     );
 
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(1));
-    assert_eq!(contract.balance_of(&Key::Account(contract.bob)), U256::from(2));
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::from(1)
+    );
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.bob)),
+        U256::from(2)
+    );
     assert_eq!(contract.total_supply(), U256::from(3));
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.bob));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.bob));
-    assert_eq!(contract.owner_of(&ali_tokens[2]), Key::Account(contract.ali));
+    assert_eq!(
+        contract.owner_of(&ali_tokens[0]),
+        Key::Account(contract.bob)
+    );
+    assert_eq!(
+        contract.owner_of(&ali_tokens[1]),
+        Key::Account(contract.bob)
+    );
+    assert_eq!(
+        contract.owner_of(&ali_tokens[2]),
+        Key::Account(contract.ali)
+    );
 }
 
 #[test]
@@ -287,12 +353,24 @@ fn test_transfer_all_tokens() {
     let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
 
     contract.transfer_all_tokens(&contract.bob.clone(), &contract.ali.clone());
-    assert_eq!(contract.balance_of(&Key::Account(contract.ali)), U256::from(0));
-    assert_eq!(contract.balance_of(&Key::Account(contract.bob)), U256::from(2));
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::from(0)
+    );
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.bob)),
+        U256::from(2)
+    );
     assert_eq!(contract.total_supply(), U256::from(2));
 
-    assert_eq!(contract.owner_of(&ali_tokens[0]), Key::Account(contract.bob));
-    assert_eq!(contract.owner_of(&ali_tokens[1]), Key::Account(contract.bob));
+    assert_eq!(
+        contract.owner_of(&ali_tokens[0]),
+        Key::Account(contract.bob)
+    );
+    assert_eq!(
+        contract.owner_of(&ali_tokens[1]),
+        Key::Account(contract.bob)
+    );
 }
 
 #[test]
@@ -314,20 +392,31 @@ fn test_token_metadata_update() {
 #[test]
 fn test_contract_owning_token() {
     let mut contract = CasperCEP47Contract::deploy();
-    let contract_hash: Hash = contract.deploy_secondary_contract("owning-contract.wasm", "owning_contract_hash", runtime_args!{});
+    let (contract_hash, package) =
+        contract.deploy_secondary_contract("owning-contract.wasm", runtime_args! {});
     let token_id = TokenId::from("123456");
     let token_meta = meta::red_dragon();
+    let owning_hash_key = Key::Hash(package);
     contract.mint_one(
-        &Key::Hash(contract_hash),
+        &owning_hash_key,
         Some(&token_id),
         &token_meta,
         &contract.admin.clone(),
     );
 
     assert_eq!(contract.total_supply(), U256::from(1));
-    assert_eq!(contract.balance_of(&Key::Hash(contract_hash)), U256::from(1));
+    assert_eq!(contract.balance_of(&owning_hash_key), U256::from(1));
 
-    let contracts_tokens: Vec<TokenId> = contract.tokens(&Key::Hash(contract_hash));
-    println!("{:?}", contracts_tokens);
-    assert_eq!(contract.owner_of(&contracts_tokens[0]), Key::Hash(contract_hash));
+    let contracts_tokens: Vec<TokenId> = contract.tokens(&owning_hash_key);
+    assert_eq!(contract.owner_of(&contracts_tokens[0]), owning_hash_key);
+
+    let admin = contract.admin;
+    let ali = Key::Account(contract.ali.to_owned());
+    contract.transfer_token_from_contract(&admin, &contract_hash, &ali, &token_id);
+
+    assert_eq!(contract.balance_of(&owning_hash_key), U256::from(0));
+    assert_eq!(
+        contract.balance_of(&Key::Account(contract.ali)),
+        U256::from(1)
+    );
 }

--- a/cep47/src/cep47_storage.rs
+++ b/cep47/src/cep47_storage.rs
@@ -33,7 +33,7 @@ impl CEP47Storage for CasperCEP47Storage {
         Balances::instance().get(owner)
     }
 
-    fn onwer_of(&self, token_id: &TokenId) -> Option<Key> {
+    fn owner_of(&self, token_id: &TokenId) -> Option<Key> {
         Owners::instance().get(token_id)
     }
 
@@ -129,7 +129,7 @@ impl CEP47Storage for CasperCEP47Storage {
 
         // Remove tokens.
         for token_id in token_ids {
-            // Remove token form the onwer's list.
+            // Remove token from the owner's list.
             // Make sure that token is owned by the recipient.
             let index = owner_tokens
                 .iter()
@@ -181,7 +181,7 @@ impl CEP47Storage for CasperCEP47Storage {
 
     fn validate_token_ids(&self, token_ids: &Vec<TokenId>) -> bool {
         for token_id in token_ids {
-            if self.onwer_of(token_id).is_some() {
+            if self.owner_of(token_id).is_some() {
                 return false;
             }
         }

--- a/cep47/src/lib.rs
+++ b/cep47/src/lib.rs
@@ -9,7 +9,10 @@ use alloc::{
     string::String,
 };
 use casper_contract::{
-    contract_api::{runtime, storage},
+    contract_api::{
+        runtime::{self, revert},
+        storage,
+    },
     unwrap_or_revert::UnwrapOrRevert,
 };
 use casper_types::{
@@ -282,7 +285,9 @@ pub fn ret<T: CLTyped + ToBytes>(value: T) {
 }
 
 fn get_caller() -> Key {
-    match runtime::get_call_stack().first().unwrap_or_revert() {
+    let mut callstack = runtime::get_call_stack();
+    callstack.pop();
+    match callstack.last().unwrap_or_revert() {
         CallStackElement::Session { account_hash } => (*account_hash).into(),
         CallStackElement::StoredSession {
             account_hash,

--- a/test-contracts/Cargo.toml
+++ b/test-contracts/Cargo.toml
@@ -16,6 +16,13 @@ bench = false
 doctest = false
 test = false
 
+[[bin]]
+name = "owning-contract"
+path = "src/owning_contract.rs"
+bench = false
+doctest = false
+test = false
+
 [features]
 default = ["casper-contract/std", "casper-types/std"]
 

--- a/test-contracts/src/owning_contract.rs
+++ b/test-contracts/src/owning_contract.rs
@@ -1,0 +1,48 @@
+#![no_main]
+
+use casper_contract::{
+    contract_api::{
+        runtime::{self},
+        storage,
+    },
+    unwrap_or_revert::UnwrapOrRevert,
+};
+use casper_types::{
+    contracts::NamedKeys, CLType, EntryPoint, EntryPointAccess, EntryPoints, Key, Parameter,
+};
+
+#[no_mangle]
+pub extern "C" fn call_back() {
+}
+
+#[no_mangle]
+pub extern "C" fn call() {
+    let (contract_package_hash, _access) = storage::create_contract_package_at_hash();
+    let entry_points = {
+        let mut eps = EntryPoints::new();
+        eps.add_entry_point(EntryPoint::new(
+            "call_back",
+            vec![],
+            CLType::Unit,
+            EntryPointAccess::Public,
+            casper_types::EntryPointType::Contract,
+        ));
+        eps
+    };
+    let named_keys = {
+        let mut nk = NamedKeys::new();
+        nk
+    };
+
+    let (contract_hash, _) =
+        storage::add_contract_version(contract_package_hash, entry_points, named_keys);
+    // wrap the contract hash so that it can be reached from the test environment
+    runtime::put_key(
+        "owning_contract_hash",
+        storage::new_uref(contract_hash).into(),
+    );
+    runtime::put_key(
+        "owning_contract_package",
+        storage::new_uref(contract_package_hash).into(),
+    );
+}


### PR DESCRIPTION
call_stack fix: the second to last entry in the vec returned by `get_call_stack` is the caller.

Introduced `owning_contract`. A contract implementation that can own and transfer out tokens. The transfer is needed to be implemented on the contract.

Some test functions are changed to use `Key` arguments.