### PR TITLE
Events via dictionaries

### DIFF
--- a/cep47-logic/src/events.rs
+++ b/cep47-logic/src/events.rs
@@ -21,4 +21,7 @@ pub enum CEP47Event {
         owner: Key,
         token_ids: Vec<TokenId>,
     },
+    Paused {
+        is_paused: bool,
+    },
 }

--- a/cep47-logic/src/lib.rs
+++ b/cep47-logic/src/lib.rs
@@ -146,7 +146,7 @@ pub trait CEP47Contract<Storage: CEP47Storage>: WithStorage<Storage> {
     }
 
     fn burn_one(&mut self, owner: &Key, token_id: TokenId) {
-        self.storage_mut().burn_many(owner, &vec![token_id]);
+        self.burn_many(owner, vec![token_id]);
     }
 
     fn burn_many(&mut self, owner: &Key, token_ids: Vec<TokenId>) {

--- a/cep47-logic/src/lib.rs
+++ b/cep47-logic/src/lib.rs
@@ -78,10 +78,14 @@ pub trait CEP47Contract<Storage: CEP47Storage>: WithStorage<Storage> {
 
     fn pause(&mut self) {
         self.storage_mut().pause();
+        self.storage_mut()
+            .emit(CEP47Event::Paused { is_paused: true });
     }
 
     fn unpause(&mut self) {
         self.storage_mut().unpause();
+        self.storage_mut()
+            .emit(CEP47Event::Paused { is_paused: false });
     }
 
     // Minter function.
@@ -205,17 +209,18 @@ pub trait CEP47Contract<Storage: CEP47Storage>: WithStorage<Storage> {
             return Err(Error::PermissionDenied);
         }
         let mut sender_tokens = self.storage().get_tokens(sender);
+        let emit_tokens = sender_tokens.clone();
         let mut recipient_tokens = self.storage().get_tokens(recipient);
         recipient_tokens.append(&mut sender_tokens);
 
-        self.storage_mut().set_tokens(sender, sender_tokens.clone());
+        self.storage_mut().set_tokens(sender, sender_tokens);
         self.storage_mut().set_tokens(recipient, recipient_tokens);
 
         // Emit transfer event.
         self.storage_mut().emit(CEP47Event::Transfer {
             sender: *sender,
             recipient: *recipient,
-            token_ids: sender_tokens,
+            token_ids: emit_tokens,
         });
 
         Ok(())

--- a/cep47-tests/src/cep47.rs
+++ b/cep47-tests/src/cep47.rs
@@ -146,6 +146,23 @@ impl CasperCEP47Contract {
         }
     }
 
+    pub fn get_event(&self, index: u32) -> BTreeMap<String, String> {
+        self.query_dictionary_value("events", index.to_string())
+            .unwrap()
+    }
+
+    pub fn get_events(&self) -> Vec<BTreeMap<String, String>> {
+        let mut events = Vec::new();
+        for i in 0..self.get_events_count() {
+            events.push(self.get_event(i));
+        }
+        events
+    }
+
+    pub fn get_events_count(&self) -> u32 {
+        self.query_contract("events_count").unwrap()
+    }
+
     pub fn name(&self) -> String {
         self.query_contract("name").unwrap()
     }

--- a/cep47-tests/src/contract_tests.rs
+++ b/cep47-tests/src/contract_tests.rs
@@ -58,6 +58,7 @@ fn test_token_meta() {
 
     let ali_tokens: Vec<TokenId> = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(ali_tokens, vec![token_id]);
+    assert_eq!(contract.get_events().len(), 1);
 }
 
 #[test]
@@ -83,6 +84,7 @@ fn test_mint_one_with_random_token_id() {
         contract.owner_of(&ali_tokens[0]),
         Key::Account(contract.ali)
     );
+    assert_eq!(contract.get_events().len(), 1);
 }
 
 #[test]
@@ -106,6 +108,7 @@ fn test_mint_one_with_set_token_id() {
     );
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::one());
     assert_eq!(contract.owner_of(&token_id), Key::Account(contract.ali));
+    assert_eq!(contract.get_events().len(), 1);
 }
 
 #[test]
@@ -120,6 +123,7 @@ fn test_mint_one_with_not_unique_token_id() {
         &token_meta,
         &contract.admin.clone(),
     );
+    assert_eq!(contract.get_events().len(), 1);
     contract.mint_one(
         &Key::Account(contract.ali),
         Some(&token_id),
@@ -159,6 +163,7 @@ fn test_mint_copies() {
         contract.owner_of(&ali_tokens[2]),
         Key::Account(contract.ali)
     );
+    assert_eq!(contract.get_events().len(), 3);
 }
 
 #[test]
@@ -188,6 +193,7 @@ fn test_mint_many() {
         contract.owner_of(&ali_tokens[1]),
         Key::Account(contract.ali)
     );
+    assert_eq!(contract.get_events().len(), 2);
 }
 
 #[test]
@@ -227,6 +233,7 @@ fn test_burn_many() {
     let ali_tokens = contract.tokens(&Key::Account(contract.ali));
     println!("{:?}", ali_tokens);
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(2));
+    assert_eq!(contract.get_events().len(), 6);
 }
 
 #[test]
@@ -255,6 +262,7 @@ fn test_burn_one() {
 
     let ali_tokens = contract.tokens(&Key::Account(contract.ali));
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(1));
+    assert_eq!(contract.get_events().len(), 3);
 }
 
 #[test]
@@ -293,6 +301,7 @@ fn test_transfer_token() {
         contract.owner_of(&ali_tokens[1]),
         Key::Account(contract.bob)
     );
+    assert_eq!(contract.get_events().len(), 3);
 }
 
 #[test]
@@ -337,6 +346,7 @@ fn test_transfer_many_tokens() {
         contract.owner_of(&ali_tokens[2]),
         Key::Account(contract.ali)
     );
+    assert_eq!(contract.get_events().len(), 5);
 }
 
 #[test]
@@ -371,6 +381,10 @@ fn test_transfer_all_tokens() {
         contract.owner_of(&ali_tokens[1]),
         Key::Account(contract.bob)
     );
+    for e in contract.get_events() {
+        println!("{:?}", e);
+    }
+    assert_eq!(contract.get_events().len(), 4);
 }
 
 #[test]
@@ -387,6 +401,7 @@ fn test_token_metadata_update() {
 
     contract.update_token_metadata(&token_id, &meta::blue_dragon(), &contract.admin.clone());
     assert_eq!(contract.token_meta(&token_id).unwrap(), meta::blue_dragon());
+    assert_eq!(contract.get_events().len(), 2);
 }
 
 #[test]
@@ -419,6 +434,7 @@ fn test_contract_owning_token() {
         contract.balance_of(&Key::Account(contract.ali)),
         U256::from(1)
     );
+    assert_eq!(contract.get_events().len(), 2);
 }
 
 #[test]
@@ -441,6 +457,7 @@ fn test_pausing_contract() {
         &ali_tokens[1],
         &contract.ali.clone(),
     );
+    assert_eq!(contract.get_events().len(), 3);
 }
 
 #[test]
@@ -482,6 +499,7 @@ fn test_pausing_and_unpausing_contract() {
     let bob_tokens = contract.tokens(&Key::Account(contract.bob));
     assert_eq!(U256::from(ali_tokens.len() as u64), U256::from(0));
     assert_eq!(U256::from(bob_tokens.len() as u64), U256::from(1));
+    assert_eq!(contract.get_events().len(), 6);
 }
 
 #[test]
@@ -490,6 +508,7 @@ fn test_pausing_contract_unauthorized() {
     // generic user cannot pause the contract
     let mut contract = CasperCEP47Contract::deploy();
     contract.pause(&contract.ali.clone());
+    assert_eq!(contract.get_events().len(), 1);
 }
 
 #[test]
@@ -499,6 +518,7 @@ fn test_unpausing_contract_unauthorized() {
     let mut contract = CasperCEP47Contract::deploy();
     contract.pause(&contract.admin.clone());
     contract.unpause(&contract.ali.clone());
+    assert_eq!(contract.get_events().len(), 2);
 }
 
 #[test]
@@ -509,4 +529,5 @@ fn test_paused_field() {
     assert!(contract.is_paused());
     contract.unpause(&contract.admin.clone());
     assert!(!contract.is_paused());
+    assert_eq!(contract.get_events().len(), 2);
 }

--- a/cep47/src/data.rs
+++ b/cep47/src/data.rs
@@ -305,6 +305,16 @@ pub fn emit(event: &CEP47Event) {
                 events_count += 1;
             }
         }
+        CEP47Event::Paused { is_paused } => {
+            let mut event = BTreeMap::new();
+            let event_id = events_count.to_string();
+            event.insert("event_id", event_id.clone());
+            event.insert("contract_package_hash", package.to_string());
+            event.insert("event_type", "paused".to_string());
+            event.insert("is_paused", is_paused.to_string());
+            events.push((event_id, event));
+            events_count += 1;
+        }
     };
 
     let events_dict = Dict::at(EVENTS_DICT);

--- a/test-contracts/src/dragons-nft.rs
+++ b/test-contracts/src/dragons-nft.rs
@@ -1,18 +1,29 @@
 #![no_main]
 
-use casper_contract::contract_api::runtime::get_named_arg;
+use casper_contract::contract_api::runtime::{self, get_named_arg};
 use casper_contract::contract_api::storage::create_contract_package_at_hash;
 
 #[no_mangle]
 pub extern "C" fn call() {
-    let (contract_package_hash, _) = create_contract_package_at_hash();
+    let token_name: String = get_named_arg("token_name");
+    let token_symbol: String = get_named_arg("token_symbol");
+    let token_meta: cep47::Meta = get_named_arg("token_meta");
+
+    let (contract_package_hash, access_token) = create_contract_package_at_hash();
     let entry_points = cep47::get_entrypoints(Some(contract_package_hash));
+
     cep47::deploy(
-        get_named_arg::<String>("token_name"),
-        get_named_arg::<String>("token_symbol"),
-        get_named_arg::<cep47::Meta>("token_meta"),
+        token_name.clone(),
+        token_symbol,
+        token_meta,
         entry_points,
         contract_package_hash,
         false,
     );
+
+    runtime::put_key(
+        &format!("{}_package_hash", token_name),
+        contract_package_hash.into(),
+    );
+    runtime::put_key(&format!("{}_access_token", token_name), access_token.into());
 }


### PR DESCRIPTION
Throwing events via storage::new_uref is not efficient. Saving events to the dictionary is lighter and allows to verify that event was thrown by the contract.